### PR TITLE
rpi-image: Integrate the minimal ssh server

### DIFF
--- a/meta-rpi-adaptation/recipes-core/images/core-rpi-image.bb
+++ b/meta-rpi-adaptation/recipes-core/images/core-rpi-image.bb
@@ -1,6 +1,7 @@
 SUMMARY = "A custom console-only image that fully supports the target device hardware."
 
-IMAGE_FEATURES += "splash"
+# IMAGE_FEATURES - List of features to be included into the image
+IMAGE_FEATURES += "ssh-server-dropbear"
 
 LICENSE = "MIT"
 


### PR DESCRIPTION
This commit extends the rpi-image with the predefined package minimal ssh server.

Closes #2 