### PR TITLE
Issue 14 implement device tree overlay to define gpio line names v2

### DIFF
--- a/meta-rpi-adaptation/conf/layer.conf
+++ b/meta-rpi-adaptation/conf/layer.conf
@@ -18,3 +18,5 @@ LAYERVERSION_rpi-adaptation = "1"
 LAYERSERIES_COMPAT_rpi-adaptation = "dunfell"
 # LAYERDEPENDS - Layer dependency
 LAYERDEPENDS_rpi-adaptation = "core"
+
+require conf/machine/linux-rpi.inc

--- a/meta-rpi-adaptation/conf/machine/linux-rpi.inc
+++ b/meta-rpi-adaptation/conf/machine/linux-rpi.inc
@@ -1,0 +1,5 @@
+#@TYPE: Machine
+#@NAME: RaspberryPi 2 Development Board Extension
+#@DESCRIPTION: DTB overlay specification for the RaspberryPi 2
+
+RPI_KERNEL_DEVICETREE_OVERLAYS_append = "overlays/gpio-line-names-bcm2709.dtbo"

--- a/meta-rpi-adaptation/recipes-bsp/bootfiles/rpi-config_git.bbappend
+++ b/meta-rpi-adaptation/recipes-bsp/bootfiles/rpi-config_git.bbappend
@@ -1,0 +1,5 @@
+# Enable GPIO line names
+do_deploy_append_raspberrypi2() {
+    echo "# Enable GPIO line names" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+    echo "dtoverlay=gpio-line-names-bcm2709">>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+}

--- a/meta-rpi-adaptation/recipes-kernel/linux/files/0001-kernel-src-Specify-the-gpio-lines-name-property.patch
+++ b/meta-rpi-adaptation/recipes-kernel/linux/files/0001-kernel-src-Specify-the-gpio-lines-name-property.patch
@@ -1,0 +1,105 @@
+From 3c303d4cf98bfdafdb933e6313acd189352dd0d5 Mon Sep 17 00:00:00 2001
+From: Joel Pinto <joelpostman97@gmail.com>
+Date: Sat, 5 Mar 2022 23:38:13 +0000
+Subject: [PATCH] kernel-src: Specify the gpio-lines-name property
+
+To identify the gpios base on their names when using the libgpiod tools,
+the gpio-line-names property must be defined, for such, this commit
+implements a device tree overlay to describe this desired hardware property.
+
+Signed-off-by: Joel Pinto <joelpostman97@gmail.com>
+---
+ arch/arm/boot/dts/overlays/Makefile           |  1 +
+ .../gpio-line-names-bcm2709-overlay.dts       | 68 +++++++++++++++++++
+ 2 files changed, 69 insertions(+)
+ create mode 100644 arch/arm/boot/dts/overlays/gpio-line-names-bcm2709-overlay.dts
+
+diff --git a/arch/arm/boot/dts/overlays/Makefile b/arch/arm/boot/dts/overlays/Makefile
+index ab9fa47c8876..2c0c831ab4d3 100644
+--- a/arch/arm/boot/dts/overlays/Makefile
++++ b/arch/arm/boot/dts/overlays/Makefile
+@@ -52,6 +52,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
+ 	gpio-ir.dtbo \
+ 	gpio-ir-tx.dtbo \
+ 	gpio-key.dtbo \
++	gpio-line-names-bcm2709.dtbo \
+ 	gpio-no-bank0-irq.dtbo \
+ 	gpio-no-irq.dtbo \
+ 	gpio-poweroff.dtbo \
+diff --git a/arch/arm/boot/dts/overlays/gpio-line-names-bcm2709-overlay.dts b/arch/arm/boot/dts/overlays/gpio-line-names-bcm2709-overlay.dts
+new file mode 100644
+index 000000000000..d689600c5051
+--- /dev/null
++++ b/arch/arm/boot/dts/overlays/gpio-line-names-bcm2709-overlay.dts
+@@ -0,0 +1,68 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++        compatible = "brcm, bcm2836";
++
++        fragment@0 {
++                target = <&gpio>;
++                __overlay__ {
++                        gpio-line-names = "ID_SDA",
++                          "ID_SCL",
++                          "SDA1",
++                          "SCL1",
++                          "GPIO_GCLK",
++                          "GPIO5",
++                          "GPIO6",
++                          "SPI_CE1_N",
++                          "SPI_CE0_N",
++                          "SPI_MISO",
++                          "SPI_MOSI",
++                          "SPI_SCLK",
++                          "GPIO12",
++                          "GPIO13",
++                          /* Serial port */
++                          "TXD0",
++                          "RXD0",
++                          "GPIO16",
++                          "GPIO17",
++                          "GPIO18",
++                          "GPIO19",
++                          "GPIO20",
++                          "GPIO21",
++                          "GPIO22",
++                          "GPIO23",
++                          "GPIO24",
++                          "GPIO25",
++                          "GPIO26",
++                          "GPIO27",
++                          "SDA0",
++                          "SCL0",
++                          "NC", /* GPIO30 */
++                          "LAN_RUN",
++                          "CAM_GPIO1",
++                          "NC", /* GPIO33 */
++                          "NC", /* GPIO34 */
++                          "PWR_LOW_N",
++                          "NC", /* GPIO36 */
++                          "NC", /* GPIO37 */
++                          "USB_LIMIT",
++                          "NC", /* GPIO39 */
++                          "PWM0_OUT",
++                          "CAM_GPIO0",
++                          "SMPS_SCL",
++                          "SMPS_SDA",
++                          "ETH_CLK",
++                          "PWM1_OUT",
++                          "HDMI_HPD_N",
++                          "STATUS_LED",
++                          /* Used by SD Card */
++                          "SD_CLK_R",
++                          "SD_CMD_R",
++                          "SD_DATA0_R",
++                          "SD_DATA1_R",
++                          "SD_DATA2_R",
++                          "SD_DATA3_R";
++                };
++        };
++};
+-- 
+2.17.1
+

--- a/meta-rpi-adaptation/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+++ b/meta-rpi-adaptation/recipes-kernel/linux/linux-raspberrypi_%.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = " \
+    file://0001-kernel-src-Specify-the-gpio-lines-name-property.patch \
+"


### PR DESCRIPTION
With the currently employed linux-rpi branch, the gpio line names are not described by the device tree. To ease the future integration of the custom LKM for gpio lines interface, the line names should be described. For such, this commit implements and integrates an overlay with the gpio-line-names property defined.

Closes #14 