### PR TITLE
Conf: Update the init manager definition metadata into a meta-layer d…

### DIFF
--- a/meta-rpi-adaptation/conf/distro/rpi-adaptation.conf
+++ b/meta-rpi-adaptation/conf/distro/rpi-adaptation.conf
@@ -1,0 +1,1 @@
+INIT_MANAGER="systemd"

--- a/meta-rpi-adaptation/conf/layer.conf
+++ b/meta-rpi-adaptation/conf/layer.conf
@@ -20,3 +20,4 @@ LAYERSERIES_COMPAT_rpi-adaptation = "dunfell"
 LAYERDEPENDS_rpi-adaptation = "core"
 
 require conf/machine/linux-rpi.inc
+require conf/distro/rpi-adaptation.conf

--- a/meta-rpi-adaptation/conf/local.conf.sample
+++ b/meta-rpi-adaptation/conf/local.conf.sample
@@ -268,5 +268,3 @@ CONF_VERSION = "1"
 
 # Specifies the argument enable_uart=1 to be passed to the kernel during boot
 ENABLE_UART = "1"
-
-INIT_MANAGER = "systemd"


### PR DESCRIPTION
…isto configuration file

With this migration, we ensure that the systemd as init manager is specific for the rpi-image
(reducing cross images dependency).

Closes #15 